### PR TITLE
Fix incorrect comparison messages for the guessing game

### DIFF
--- a/guess_game.py
+++ b/guess_game.py
@@ -10,9 +10,9 @@ def guess_number():
         attempts += 1
 
         if guess > target:
-            print("Too low! Try again.")
-        elif guess < target:
             print("Too high! Try again.")
+        elif guess < target:
+            print("Too low! Try again.")
         else:
             print(f"Congratulations! You guessed it in {attempts} attempts.")
             break


### PR DESCRIPTION
### Issue: New direction issue

Hi,
I have been trying to play the guessing_game.py but I realized when I guess 3, the program says "Too high! Try again." so I try 2 and 1 but I still get "Too high! Try again." response. This doesn't make sense as the game asks me to guess a number between 1 and 100 and there is no number smaller than 1 in that range.

### Commit message: Fix incorrect comparison messages for the guessing game.

**Explanation**: The issue was due to an incorrect comparison print statement. The messages for 'Too low!' and 'Too high!' were swapped. The correct implementation should print 'Too high!' when the guess is greater than the target and 'Too low!' when the guess is less than the target.

### Changes made:
- Swap the print messages for 'Too high!' and 'Too low!' in the guessing_game.py.

### Impact:
- This change ensures the game provides correct feedback to the player, enhancing user experience and making the game functional as intended.

This PR fixes #11