### PR TITLE
bugfix: guessing game - incorrect instructions

### DIFF
--- a/guess_game.py
+++ b/guess_game.py
@@ -9,9 +9,9 @@ def guess_number():
         guess = int(input("Guess a number between 1 and 100: "))
         attempts += 1
 
-        if guess > target:
+        if guess < target:
             print("Too low! Try again.")
-        elif guess < target:
+        elif guess > target:
             print("Too high! Try again.")
         else:
             print(f"Congratulations! You guessed it in {attempts} attempts.")


### PR DESCRIPTION
Fix incorrect instructions in the guessing game

The original code was incorrectly checking if the guess was greater than the target, which would result in 'Too high' being printed when the guess was actually lower. The condition has been corrected to check if the guess is less than the target instead.

This PR fixes #35