### PR TITLE
bugfix: wrong instructions

### DIFF
--- a/guess_game.py
+++ b/guess_game.py
@@ -9,9 +9,9 @@ def guess_number():
         guess = int(input("Guess a number between 1 and 100: "))
         attempts += 1
 
-        if guess > target:
+        if guess < target:
             print("Too low! Try again.")
-        elif guess < target:
+        elif guess > target:
             print("Too high! Try again.")
         else:
             print(f"Congratulations! You guessed it in {attempts} attempts.")


### PR DESCRIPTION
Fix issue with number guessing game where it incorrectly said 'too low' when the guess was within the valid range.

The original code incorrectly checked if the guess was greater than the target, which would always be true since the target is within the range of 1 to 100. The condition has been corrected to check if the guess is less than the target.

This PR fixes #50